### PR TITLE
Update the role to work with the `latest` prometheus image

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,8 +29,10 @@ prometheus_commandline_args:
   storage.tsdb.path: "/prometheus-data/data"
 prometheus_image: "prom/prometheus"
 
-prometheus_rule_files:
-  - '/prometheus-data/alert.rules'
+# Fileglobs loop format
+# http://docs.ansible.com/ansible/latest/playbooks_loops.html#id4
+prometheus_rule_files: []
+
 # See https://prometheus.io/docs/operating/configuration/#<scrape_config>
 prometheus_scrape_configs:
 - job_name: 'prometheus'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,11 @@ prometheus_image: "prom/prometheus"
 # http://docs.ansible.com/ansible/latest/playbooks_loops.html#id4
 prometheus_rule_files: []
 
+# Telegraf rules
+prometheus_telegraf_rules_config: {}
+#  receiver: slack
+
+
 # See https://prometheus.io/docs/operating/configuration/#<scrape_config>
 prometheus_scrape_configs:
 - job_name: 'prometheus'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ prometheus_evaluation_interval: 15s
 prometheus_external_labels: ''
 prometheus_commandline_args:
   config.file: "/prometheus-data/prometheus.yml"
-  storage.local.path: "/prometheus-data/data"
+  storage.tsdb.path: "/prometheus-data/data"
 
 prometheus_rule_files:
   - '/prometheus-data/alert.rules'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ prometheus_external_labels: ''
 prometheus_commandline_args:
   config.file: "/prometheus-data/prometheus.yml"
   storage.tsdb.path: "/prometheus-data/data"
+prometheus_image: "prom/prometheus"
 
 prometheus_rule_files:
   - '/prometheus-data/alert.rules'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,6 @@ prometheus_evaluation_interval: 15s
 prometheus_external_labels: ''
 prometheus_commandline_args:
   config.file: "/prometheus-data/prometheus.yml"
-  alertmanager.url: "http://{{ alertmanager_ip }}:9093"
   storage.local.path: "/prometheus-data/data"
 
 prometheus_rule_files:
@@ -43,6 +42,13 @@ prometheus_scrape_configs:
   static_configs:
     - targets:
       - "{{ ansible_default_ipv4.address }}:9100"
+
+prometheus_alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "{{ alertmanager_ip }}:9093"
 
 # Alertmanager configuration file
 alertmanager_route:

--- a/files/alert.rules
+++ b/files/alert.rules
@@ -1,44 +1,52 @@
-ALERT InstanceDown
-  IF up == 0
-  FOR 2m
-  LABELS { severity = "critical" }
-  ANNOTATIONS {
-    summary = "Instance {{ $labels.instance }} down",
-    description = "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.",
-  }
+groups:
+- name: alert.rules
+  rules:
+  - alert: HighMem
+    expr: 100 - (node_memory_MemFree + node_memory_Buffers + node_memory_Cached) /
+      node_memory_MemTotal * 100 > 90
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: '{{$labels.host}} of job {{$labels.job}} has less than 40% of memory
+        available for more than 1 minutes.'
+      summary: Instance {{$labels.host}} has high memory consumption
+  - alert: HighLoad
+    expr: node_load1 > 4
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: '{{$labels.host}} of job {{$labels.job}} has high load  for more
+        than 1 minutes.'
+      summary: Instance {{$labels.host}} {{$labels.instance}} has high load
+  - alert: HighCPU
+    expr: sum(irate(node_cpu{mode="user"}[5m])) BY (host, mode) * 100 / scalar(count(count(node_cpu)
+      BY (cpu))) > 50
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: '{{$labels.host}} of job {{$labels.job}} has been consuming > 50%
+        cpi for more than 1 minutes.'
+      summary: Instance {{$labels.host}} {{$labels.instance}} has high cpu
+  - alert: LowDiskSpace
+    expr: 100 - node_filesystem_free{job="node_exporter"} / node_filesystem_size{job="node_exporter"}
+      * 100 > 80
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: disk space on {{$labels.host}} {{$labels.instance}} lower than
+        20%
+      summary: disk space on {{$labels.host}} {{$labels.instance}} lower than 20%
+  - alert: InstanceDown
+    expr: up == 0
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: '{{ $labels.instance }} of job {{ $labels.job }} has been down
+        for more than 5 minutes.'
+      summary: Instance {{ $labels.instance }} down
 
-ALERT HighMem
-  IF 100 -(node_memory_MemFree + node_memory_Buffers + node_memory_Cached) / node_memory_MemTotal* 100 > 90
-  FOR 2m
-  LABELS { severity = "warning" }
-  ANNOTATIONS {
-    summary = "Instance {{$labels.host}} has high memory consumption",
-    description = "{{$labels.host}} of job {{$labels.job}} has less than 40% of memory available for more than 1 minutes.",
-  }
-
-ALERT HighLoad
-  IF node_load1 > 4
-  FOR 2m
-  LABELS { severity = "warning" }
-  ANNOTATIONS {
-    summary = "Instance {{$labels.host}} {{$labels.instance}} has high load",
-    description = "{{$labels.host}} of job {{$labels.job}} has high load  for more than 1 minutes.",
-  }
-
-ALERT HighCPU
-  IF sum by (host,mode)(irate(node_cpu{mode='user'}[5m])) * 100 / scalar(count(count by (cpu)(node_cpu))) > 50
-  FOR 2m
-  LABELS { severity = "warning" }
-  ANNOTATIONS {
-    summary = "Instance {{$labels.host}} {{$labels.instance}} has high cpu",
-    description = "{{$labels.host}} of job {{$labels.job}} has been consuming > 50% cpi for more than 1 minutes.",
-  }
-
-ALERT LowDiskSpace
-  IF 100 - node_filesystem_free{job="node_exporter"} / node_filesystem_size{job="node_exporter"} * 100 > 80
-  FOR 2m
-  LABELS { severity = "warning" }
-  ANNOTATIONS {
-    summary = "disk space on {{$labels.host}} {{$labels.instance}} lower than 20%",
-    description = "disk space on {{$labels.host}} {{$labels.instance}} lower than 20%",
-  }

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -4,7 +4,7 @@
     name: prometheus
     command: "{% for key in prometheus_commandline_args %}--{{key}}={{prometheus_commandline_args[key]}} {% endfor %}"
     hostname: "{{ prometheus_hostname }}"
-    image: prom/prometheus
+    image: "{{ prometheus_image }}"
     volumes:
       - "{{ path }}/prometheus-data:/prometheus-data"
     published_ports:

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -39,3 +39,14 @@
   notify:
     - "{{ prometheus_restart_handler }}"
   when: default_alert_rules == true
+
+- name: copy prometheus rules
+  copy: >
+    src="{{ item }}"
+    dest="{{ path }}/prometheus-data/{{ item | basename }}.rules"
+    owner=root
+    group=nogroup
+    mode=0640
+  with_fileglob: "{{ prometheus_rule_files }}"
+  notify:
+    - "{{ prometheus_restart_handler }}"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -41,7 +41,7 @@
   when: default_alert_rules == true
 
 - name: copy prometheus rules
-  copy: >
+  template: >
     src="{{ item }}"
     dest="{{ path }}/prometheus-data/{{ item | basename }}.rules"
     owner=root

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -11,12 +11,20 @@
       - 9090:9090
     restart_policy: always
 
+- name: ensure prometheus data directory owner is nobody
+  file: >
+    path="{{ path }}/prometheus-data"
+    owner=nobody
+    group=nogroup
+    mode=0740
+    state=directory
+
 - name: copy prometheus config file
   template: >
     src=templates/prometheus.yml.j2
     dest="{{ path }}/prometheus-data/prometheus.yml"
     owner=root
-    group=root
+    group=nogroup
     mode=0640
   notify:
     - "{{ prometheus_restart_handler }}"
@@ -26,7 +34,7 @@
     src=files/alert.rules
     dest="{{ path }}/prometheus-data/alert.rules"
     owner=root
-    group=root
+    group=nogroup
     mode=0640
   notify:
     - "{{ prometheus_restart_handler }}"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -2,7 +2,7 @@
 - name: Create prometheus container
   docker_container:
     name: prometheus
-    command: "{% for key in prometheus_commandline_args %}-{{key}}={{prometheus_commandline_args[key]}} {% endfor %}"
+    command: "{% for key in prometheus_commandline_args %}--{{key}}={{prometheus_commandline_args[key]}} {% endfor %}"
     hostname: "{{ prometheus_hostname }}"
     image: prom/prometheus
     volumes:

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -7,9 +7,9 @@ global:
     {{ key }}: {{ prometheus_external_labels[key] }}
 {% endfor %}
 {% endif %}
-{% if default_alert_rules %}
+{% if default_alert_rules or prometheus_rule_files %}
 rule_files:
-{{ prometheus_rule_files | to_json | from_json | to_nice_yaml }}
+- /prometheus-data/*.rules
 {% endif %}
 scrape_configs:
 {{ prometheus_scrape_configs | to_json | from_json | to_nice_yaml( width=50, explicit_start=False, explicit_end=False) }}

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -13,3 +13,5 @@ rule_files:
 {% endif %}
 scrape_configs:
 {{ prometheus_scrape_configs | to_json | from_json | to_nice_yaml( width=50, explicit_start=False, explicit_end=False) }}
+alerting:
+{{ prometheus_alerting | to_json | from_json | to_nice_yaml( width=50, explicit_start=False, explicit_end=False) | indent(2, indentfirst=True) }}

--- a/templates/telegraf.rules
+++ b/templates/telegraf.rules
@@ -1,0 +1,331 @@
+groups:
+#
+# System
+#
+- name: telegraf.rules
+  rules:
+  #
+  # System
+  #
+  - alert: CPUUsage
+    expr: (100 - cpu_usage_idle{cpu="cpu-total"}) > 90
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{$labels.instance}}: CPU usage is above 90% (current value is: {{ $value }})'
+      summary: '{{$labels.instance}}: High CPU usage detected'
+    {% endraw %}
+
+  - alert: MemoryUsage
+    expr: (100 - mem_available_percent) > 90
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{$labels.instance}}: Memory usage is above 90% (current value is: {{ $value }})'
+      summary: '{{$labels.instance}}: High memory usage detected'
+    {% endraw %}
+
+  - alert: LoadAverage
+    expr: (system_load5 / system_n_cpus) > 2.5
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{$labels.instance}}: LoadAverage is high (current value is: {{ $value }} per cpu)'
+      summary: '{{$labels.instance}}: High LoadAverage detected'
+    {% endraw %}
+
+  - alert: LowDiskSpace
+    expr: disk_used_percent > 90
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{$labels.instance}}: {{$labels.path}} disk usage is above 90% (current value is: {{ $value }})'
+      summary: '{{$labels.instance}}: Low disk space'
+    {% endraw %}
+
+  - alert: LowDiskInodes
+    expr: ((disk_inodes_used / disk_inodes_total) * 100) > 90
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{$labels.instance}}: {{$labels.path}} disk inodes is above 90% (current value is: {{ $value }})'
+      summary: '{{$labels.instance}}: Low disk inodes'
+    {% endraw %}
+
+  # Do not raise down alarm for preprod and dev instances
+  - alert: InstanceDown
+    expr: up{env !~ "dev|preprod|staging"} == 0
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - {{ $labels.Name }} has been down for more than 5 minutes.'
+      summary: 'Instance {{ $labels.instance }} down'
+    {% endraw %}
+
+  #
+  # Http
+  #
+  - alert: HttpResponseCode
+    expr: http_response_http_response_code > 302
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - {{ $labels.server }} return code > 302 for more than 5 minutes.'
+      summary: 'Instance {{ $labels.instance }} return code {{ $value }} > 302'
+    {% endraw %}
+
+  - alert: HttpResponseStringMatch
+    expr: http_response_response_string_match == 0
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - {{ $labels.server }} not able to match the requested string for more than 5 minutes.'
+      summary: 'Instance {{ $labels.instance }} - {{ $labels.server }} pattern not found'
+    {% endraw %}
+
+  # Using min_over_time https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation-_over_time
+  # As we run this check only every 30min, there is some hole in the graph.
+  # So we are taking the min value to have enough data for the alert. Keeping in mind that this alert should
+  # Change value only once a day. Having a 1h step is ok.
+  - alert: LbCertsExpireCheck
+    expr: min_over_time(aws_lb_certs_expire_days[1h]) < 30
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - cert {{ $labels.cert }} for {{ $labels.cert_cn }} will expire in {{ $value }} days.'
+      summary: 'Instance {{ $labels.instance }} - found cert {{ $labels.cert_cn }} will expire in {{ $value }} days'
+    {% endraw %}
+
+  #
+  # Mongodb
+  #
+#  # TODO migrate this on mongodb_db_stats.
+#  # For now Telegraf from debian too old to enable gather_db_stats https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mongodb/README.md
+#  - alert: MongodbOk
+#    expr: mongodb_ok == 0
+#    for: 5m
+#    labels:
+#      {% raw -%}
+#      customer: '{{ $labels.client }}'
+#      project: '{{ $labels.project }}'
+#      env: '{{ $labels.env }}'
+#      {% endraw -%}
+#      severity: critical
+#      receiver: on_call
+#    annotations:
+#    {%- raw %}
+#      description: '{{ $labels.instance }} - Mongodb not ok for more than 5 minutes.'
+#      summary: 'Instance {{ $labels.instance }} Ko'
+#    {% endraw %}
+
+  #
+  # Amazon SES
+  #
+  - alert: SesSentQuota
+    expr: ( sum (aws_ses_quota{type="sent"}) without (type) / sum (aws_ses_quota{type="max"}) without (type) ) * 100 > 90
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - SES sent {{ $value }}% quota used.'
+      summary: '{{ $labels.instance }} - SES sent {{ $value }}% quota used.'
+    {% endraw %}
+
+  - alert: SesReputation
+    expr: (aws_ses_reputation{type="bounces"} or aws_ses_reputation{type="complaints"}) > 10
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - SES {{ $labels.type }} reputation is {{ $value }}.'
+      summary: '{{ $labels.instance }} - SES {{ $labels.type }} reputation is {{ $value }}.'
+    {% endraw %}
+
+  #
+  # Amazon CPUCredit
+  #
+  - alert: EC2CpuCreditBalance
+    expr: cloudwatch_aws_ec2_cpu_credit_balance_average < 30
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - Aws RDS {{ $labels.instance_id }} CPU Credit Balance low {{ $value }}.'
+      summary: '{{ $labels.instance }} - Aws RDS {{ $labels.instance_id }} CPU Credit Balance low {{ $value }}.'
+    {% endraw %}
+
+  - alert: RDSCpuCreditBalance
+    expr: cloudwatch_aws_rds_cpu_credit_balance_average < 30
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: critical
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - Aws RDS {{ $labels.db_instance_identifier }} CPU Credit Balance low {{ $value }}.'
+      summary: '{{ $labels.instance }} - Aws RDS {{ $labels.db_instance_identifier }} CPU Credit Balance low {{ $value }}.'
+    {% endraw %}
+
+  #
+  # Amazon Events
+  #
+  - alert: EC2Events
+    expr: aws_ec2_instance_events > 0
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: warning
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - Aws EC2 instance {{ $labels.instance_id }} has {{ $value }} scheduled events.'
+      summary: '{{ $labels.instance }} - Aws EC2 instance {{ $labels.instance_id }} has {{ $value }} scheduled events.'
+    {% endraw %}
+
+  - alert: RDSEvents
+    expr: aws_rds_instance_events > 0
+    for: 5m
+    labels:
+      {% raw -%}
+      customer: '{{ $labels.client }}'
+      project: '{{ $labels.project }}'
+      role: '{{ $labels.role }}'
+      env: '{{ $labels.env }}'
+      {% endraw -%}
+      severity: warning
+      receiver: on_call
+    annotations:
+    {%- raw %}
+      description: '{{ $labels.instance }} - Aws RDS instance {{ $labels.instance_id }} has {{ $value }} scheduled events.'
+      summary: '{{ $labels.instance }} - Aws RDS instance {{ $labels.instance_id }} has {{ $value }} scheduled events.'
+    {% endraw %}
+
+
+## This alarm should always ring to trigger a curl on opsgenie heartbeat
+#- name: opsgenie.rules
+#  rules:
+#  - alert: opsgenie heartbeat
+#    expr: absent(absent(prometheus_build_info == 1))
+#    labels:
+#      env: "{{ env }}"
+#      severity: critical
+#      receiver: opsgenie_heartbeat
+#    annotations:
+#      description: 'Test if prometheus and alert manager still working'
+#      summary: 'Prometheus and alertmanager service working'

--- a/templates/telegraf.rules
+++ b/templates/telegraf.rules
@@ -18,7 +18,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{$labels.instance}}: CPU usage is above 90% (current value is: {{ $value }})'
@@ -36,7 +36,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{$labels.instance}}: Memory usage is above 90% (current value is: {{ $value }})'
@@ -54,7 +54,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{$labels.instance}}: LoadAverage is high (current value is: {{ $value }} per cpu)'
@@ -72,7 +72,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{$labels.instance}}: {{$labels.path}} disk usage is above 90% (current value is: {{ $value }})'
@@ -90,7 +90,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{$labels.instance}}: {{$labels.path}} disk inodes is above 90% (current value is: {{ $value }})'
@@ -109,7 +109,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - {{ $labels.Name }} has been down for more than 5 minutes.'
@@ -130,7 +130,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - {{ $labels.server }} return code > 302 for more than 5 minutes.'
@@ -148,7 +148,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - {{ $labels.server }} not able to match the requested string for more than 5 minutes.'
@@ -170,7 +170,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - cert {{ $labels.cert }} for {{ $labels.cert_cn }} will expire in {{ $value }} days.'
@@ -192,7 +192,7 @@ groups:
 #      env: '{{ $labels.env }}'
 #      {% endraw -%}
 #      severity: critical
-#      receiver: on_call
+#      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
 #    annotations:
 #    {%- raw %}
 #      description: '{{ $labels.instance }} - Mongodb not ok for more than 5 minutes.'
@@ -213,7 +213,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - SES sent {{ $value }}% quota used.'
@@ -231,7 +231,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - SES {{ $labels.type }} reputation is {{ $value }}.'
@@ -252,7 +252,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - Aws RDS {{ $labels.instance_id }} CPU Credit Balance low {{ $value }}.'
@@ -270,7 +270,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: critical
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - Aws RDS {{ $labels.db_instance_identifier }} CPU Credit Balance low {{ $value }}.'
@@ -291,7 +291,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: warning
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - Aws EC2 instance {{ $labels.instance_id }} has {{ $value }} scheduled events.'
@@ -309,7 +309,7 @@ groups:
       env: '{{ $labels.env }}'
       {% endraw -%}
       severity: warning
-      receiver: on_call
+      receiver: {{ prometheus_telegraf_rules_config['receiver'] | default('on_call') }}
     annotations:
     {%- raw %}
       description: '{{ $labels.instance }} - Aws RDS instance {{ $labels.instance_id }} has {{ $value }} scheduled events.'

--- a/test/integration/default/serverspec/prometheus_spec.rb
+++ b/test/integration/default/serverspec/prometheus_spec.rb
@@ -4,10 +4,17 @@ require data_file if File.file? data_file
 
 describe 'Prometheus' do
 
-  %w(/srv /srv/prometheus-data /srv/alertmanager ).each do |dir|
+  %w(/srv /srv/alertmanager ).each do |dir|
     describe file(dir) do
       it { should be_directory }
       it { should be_owned_by('root') }
+    end
+  end
+
+  %w(/srv/prometheus-data ).each do |dir|
+    describe file(dir) do
+      it { should be_directory }
+      it { should be_owned_by('nobody') }
     end
   end
 
@@ -31,7 +38,12 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
     -   targets:
-        - 10.0.2.15:9100"
+        - 10.0.2.15:9100
+alerting:
+  alertmanagers:
+  -   scheme: http
+      static_configs:
+      -   targets:"
 
     it { should be_file }
     it { should contain(prometheus_content) }
@@ -39,7 +51,7 @@ scrape_configs:
 
   describe file('/srv/prometheus-data/alert.rules') do
     it { should be_file }
-    its(:content) { should match /ALERT InstanceDown/ }
+    its(:content) { should match /alert: InstanceDown/ }
   end
 
   describe file('/srv/alertmanager/alertmanager.yml') do


### PR DESCRIPTION
This PR contain several commits. Don't hesitate if you want me to split some in several pull requests

  * 1b962b7 Update kitchenCI tests.
  * 36cd978 Update alert rules file for prometheus 2
  * a8bd39c Docker: add prometheus_image variable to be able to specify prometheus image
  * 1875655 docker: ensure prometheus data directory owner is nobody
  * d3ad420 Prometheus arg storage.local.path is no called storage.tsdb.path
  * 067ecc2 prometheus alertmanager.url arg is not working anymore
  * 9939db1 Fixing prometheus_commandline_args key, new prometheus use double dash.



-----------------------------------------------------------------------------------
commit 9939db1124e89ae9b8c6ec80ce61b2d159c45a6b
Author: gaelL <contact@gaell.info>
Date:   Thu Nov 30 14:11:19 2017 +0100

    Fixing prometheus_commandline_args key, new prometheus use double dash.

    With the defaul configuration of this playbook, we hit this error

    ```
    Error parsing commandline arguments: unknown short flag '-c'
    prometheus: error: unknown short flag '-c'
    ```

    New prometheus version use double dash `--` https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file

-----------------------------------------------------------------------------------
commit 067ecc27059069fd46e46ee7773331f534b10ec1
Author: gaelL <contact@gaell.info>
Date:   Thu Nov 30 14:30:12 2017 +0100

    prometheus alertmanager.url arg is not working anymore

    The latest image of prometheus is now working with alertmanager.url arg

    ```
    Error parsing commandline arguments: unknown long flag '--alertmanager.url'
    prometheus: error: unknown long flag '--alertmanager.url'
    ```

    Rmove alertmanager.url arg arg and add alertmanager config in prometheus config file.

-----------------------------------------------------------------------------------
commit d3ad42026c06afd2114ad80ae54d0f77dc2c13eb
Author: gaelL <contact@gaell.info>
Date:   Thu Nov 30 14:45:14 2017 +0100

    Prometheus arg storage.local.path is no called storage.tsdb.path

    Fixing :

    ```
    Error parsing commandline arguments: unknown long flag '--storage.local.path'
    prometheus: error: unknown long flag '--storage.local.path'
    ```

    Replace `storage.local.path` by `storage.tsdb.path`
-----------------------------------------------------------------------------------
commit 1875655e8699c305af492d50ed758e66a2605944
Author: gaelL <contact@gaell.info>
Date:   Thu Nov 30 15:31:50 2017 +0100

    docker: ensure prometheus data directory owner is nobody

    Starting prometheus with the new docker image crash with this error

    ```
    level=error ts=2017-11-30T13:55:53.625898034Z caller=main.go:323 msg="Opening storage failed" err="mkdir /prometheus-data/data: permission denied"
    level=info ts=2017-11-30T13:56:53.864974067Z caller=main.go:215 msg="Starting Prometheus" version="(version=2.0.0, branch=HEAD, revision=0a74f98628a0463dddc90528220c94de5032d1a0)"
    level=info ts=2017-11-30T13:56:53.865136427Z caller=main.go:216 build_context="(go=go1.9.2, user=root@615b82cb36b6, date=20171108-07:11:59)"
    level=info ts=2017-11-30T13:56:53.865189099Z caller=main.go:217 host_details="(Linux 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u2 (2016-10-19) x86_64 cycloid-metrics0-eu-we1-infra (none))"
    level=info ts=2017-11-30T13:56:53.869220754Z caller=web.go:380 component=web msg="Start listening for connections" address=0.0.0.0:9090
    level=info ts=2017-11-30T13:56:53.872771615Z caller=main.go:314 msg="Starting TSDB"
    level=error ts=2017-11-30T13:56:53.872852932Z caller=main.go:323 msg="Opening storage failed" err="mkdir /prometheus-data/data: permission denied"
    ```

    Since https://github.com/prometheus/prometheus/commit/b2f7c8d842fd765508f8c7f5055242e8e9fdfad3 prometheus docker image user is nobody.

    Make sure prometheus can write in his data directory

-----------------------------------------------------------------------------------
commit a8bd39c2b8ccf8cf2ab3a31d5534e5f1c8d0f614
Author: gaelL <contact@gaell.info>
Date:   Thu Nov 30 15:49:07 2017 +0100

    Docker: add prometheus_image variable to be able to specify prometheus image

    Adding prometheus_image arg to be able to override the prometheus docker image url and version
-----------------------------------------------------------------------------------
commit 36cd97800351f67388239cc94bce763e010ed9ce
Author: gaelL <contact@gaell.info>
Date:   Fri Dec 1 09:30:18 2017 +0100

    Update alert rules file for prometheus 2

    Running test test of this role display this error

    ```
    level=error ts=2017-11-30T18:15:05.111331202Z caller=manager.go:485 component="rule manager" msg="loading groups failed" err="yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `ALERT I...` into rulefmt.RuleGroups"
    ```

    Linked to the fact rules format changed for a yaml one.

    This commit just update those rules with `promtool update rules alert.rules`

